### PR TITLE
fix: cut out target place a second one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ __pycache__/
 
 # files
 simulate-images/snapshots/
+simulate-images/target_images/*
+simulate-images/final_images/*
 *.png~
 *.xcf

--- a/simulate-images/target.py
+++ b/simulate-images/target.py
@@ -33,70 +33,81 @@ polygons = ["triangle", "square", "pentagon", "hexagon", "heptagon", "octagon"]
 
 # create a rotated target image and polygon
 def createTarget():
-    # choose colors for shape and letter
+    # choose shape, letter, colors, and rotation
     randColors = random.sample(list(colors.keys()), k=2)
     seed = {
         "shape": shapes[random.randint(0, 12)],
         "shapeColor": randColors[0],
         "letter": chr(random.randint(65, 90)),
         "letterColor": randColors[1],
+        "rotation": random.randint(0, 359)
     }
 
-    # open a new image
-    img = Image.new(mode="RGBA", size=vars.targetSize, color="white")
-    img_draw = ImageDraw.Draw(img)
-    img_font = ImageFont.truetype(
-        vars.resourceDir + "arial.ttf", int(vars.targetSize[0] / 2))
-
-    # draw the shape
-    if (seed["shape"] == "circle"):
-        img_draw.ellipse([0, 0, img.size],
-                         fill=colors[seed["shapeColor"]], width=0)
-    elif (seed["shape"] in special_cases):
-        with Image.open(vars.resourceDir + seed["shape"] + ".bmp") as bitFile:
-            scaleFactor = vars.targetSize[0] / bitFile.width
-            newSize = [int(bitFile.width * scaleFactor),
-                       int(bitFile.height * scaleFactor)]
-            scaledBitFile = bitFile.resize(newSize)
-            img_draw.bitmap([0, 0], scaledBitFile,
-                            fill=colors[seed["shapeColor"]])
-    else:
-        img_draw.regular_polygon(
-            [img.size[0] / 2, img.size[1] / 2, img.size[0] / 2],
-            polygons.index(seed["shape"]) + 3,
-            fill=seed["shapeColor"]
-        )
-
-    # draw the letter
-    img_draw.text(
-        [vars.targetSize[0] / 2, vars.targetSize[1] / 2],
-        seed["letter"],
-        fill=colors[seed["letterColor"]],
-        anchor="mm",
-        font=img_font
-    )
+    # create a new image, draw shape and letter
+    target = Image.new(mode="RGBA", size=vars.targetSize, color="#0000")
+    target = drawShape(target, seed["shape"], seed["shapeColor"])
+    target = drawLetter(target, seed["letter"], seed["letterColor"])
 
     # create a polygon for the target
-    polygon = box(0, 0, img.size[0], img.size[1])
+    polygon = box(0, 0, target.size[0], target.size[1])
 
     # rotate the target
-    targetRotation = random.randint(0, 359)
-    img = img.rotate(targetRotation, expand=True, fillcolor="#0000")
+    target = target.rotate(seed["rotation"], expand=True, fillcolor="#0000")
 
-    # rotate the polygon
-    # negative for different origin
-    polygon = affinity.rotate(polygon, -targetRotation)
+    # rotate the polygon (negative for different origin)
+    polygon = affinity.rotate(polygon, -seed["rotation"])
     polygon = affinity.translate(
         polygon,
         xoff=-polygon.bounds[0],
         yoff=-polygon.bounds[1]
     )  # snap to axes
 
-    return (img, polygon)
+    return (target, polygon, seed)
+
+
+# draw shape on target
+def drawShape(img, shape, color):
+    draw = ImageDraw.Draw(img)
+
+    if (shape == "circle"):
+        draw.ellipse([0, 0, img.size], fill=colors[color], width=0)
+    elif (shape in special_cases):
+        with Image.open(vars.resourceDir + shape + ".bmp") as bitFile:
+            scaleFactor = vars.targetSize[0] / bitFile.width
+            newSize = [int(bitFile.width * scaleFactor),
+                       int(bitFile.height * scaleFactor)]
+            scaledBitFile = bitFile.resize(newSize)
+            draw.bitmap([0, 0], scaledBitFile, fill=colors[color])
+    else:
+        draw.regular_polygon(
+            [img.size[0] / 2, img.size[1] / 2, img.size[0] / 2],
+            polygons.index(shape) + 3,
+            fill=color
+        )
+    
+    return img
+
+
+# draw letter on target
+def drawLetter(img, letter, color):
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.truetype(
+        vars.resourceDir + "arial.ttf", int(vars.targetSize[0] / 2))
+
+    draw.text(
+        [vars.targetSize[0] / 2, vars.targetSize[1] / 2],
+        letter,
+        fill=colors[color],
+        anchor="mm",
+        font=font
+    )
+
+    return img
 
 
 # move the target polygon to a random location within the snapshot
-def moveTarget(polygon):
+# returns None if the placement is invalid (< 30ft from t1)
+def moveTarget(polygon, t1=None):
     xMin, yMin, xMax, yMax = [int(b) for b in polygon.bounds]
     targetWidth = xMax - xMin
     targetHeight = yMax - yMin
@@ -109,5 +120,11 @@ def moveTarget(polygon):
 
     # move to location
     polygon = affinity.translate(polygon, xoff=offset[0], yoff=offset[1])
+
+    # check that it was placed at least 30 ft away from t1
+    if t1 != None:
+        dist = t1.distance(polygon) / vars.pxPerFt
+        if dist < 30:
+            return None
 
     return polygon

--- a/simulate-images/vars.py
+++ b/simulate-images/vars.py
@@ -7,6 +7,7 @@ from shapely.geometry import box
 noTargetDir = "snapshots/no-target/"
 targetDir = "snapshots/target/"
 resourceDir = "target-resources/"
+targetInfoPath = "snapshots/target-info.csv"
 
 # constants
 sensorSize = 7.9  # mm


### PR DESCRIPTION
- Make the target background transparent
- Sometimes place a second target 30 ft away

remove target background

refactoring and formatting

add todos for multiple targets

restructure placeTarget for multiple

save target info for image to csv

created generateTargetImages

No change in functionality, just abstraction to clean up main()

update the ignore for the final and target images

restructure again for multiple targets

place second target

Create a second target, place it, then check if it is at least 30 feet away from the first one. If it is, append the second target info to .yolo and .csv files.

About 5% of simulated images will have 2 targets.